### PR TITLE
🧹 Remove Unused Methods in QueryService

### DIFF
--- a/src/app/query/query.component.ts
+++ b/src/app/query/query.component.ts
@@ -8,18 +8,6 @@ export class QueryService {
     private BASE_URL = 'http://192.168.1.99:3000/'
     constructor(private http: HttpClient) { }
 
-    public getRoot() {
-        return this.http.get<any>(this.BASE_URL)
-    }
-
-    public getHealthCheck() {
-        return this.http.get<any>(this.BASE_URL + 'heartbeat')
-    }
-
-    public getQueryWithMessage(message: string) {
-        return this.http.get<any>(this.BASE_URL + `query_api/${message}`)
-    }
-
     public getQuery(message: string) {
         console.log(message)
         return this.http.get<any>(this.BASE_URL + 'query_api')


### PR DESCRIPTION
Removed three unused methods (getRoot, getHealthCheck, getQueryWithMessage) from QueryService in src/app/query/query.component.ts. Verified that no other parts of the codebase were calling these methods using grep. Build and test verification were skipped due to environmental limitations (missing node_modules and network issues), with user approval.

---
*PR created automatically by Jules for task [6710707295115569769](https://jules.google.com/task/6710707295115569769) started by @naiiytom*